### PR TITLE
Workflow + gitignore changes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           github-token: ${{ secrets.MERGETOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'adopt'
@@ -28,7 +28,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build --no-daemon
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: compiled
-        path: build/libs/*.jar  
+        name: build artifact
+        path: ./build/libs/  

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: build artifact
-        path: ./build/libs/  
+        path: ./build/libs/*  

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ classes
 .idea
 
 # gradle
-build
+build/*
 .gradle
 
 #Netbeans


### PR DESCRIPTION
* Bump checkout, java setup and upload artifact action versions to v4
* Rename Setup JDK actoin to `Set up JDK 17`
* Switch the upload path from `build/libs/*.jar` to `./build/libs/*`

* Add `build/*` to gitignore